### PR TITLE
Add a Dockerfile including DCNv2 GPU compilation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2.3"
+services:
+  dev:
+    image: centertrack_dev
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    tty: true
+    working_dir: /work
+    ipc: host
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,98 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+# Add sudo
+RUN apt-get -y install sudo
+RUN apt-get install -y --no-install-recommends software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt update
+RUN apt install -y --no-install-recommends python3.6
+
+# Default to python3
+RUN cd /usr/bin && ln -s python3.6 python
+RUN apt-get install -y --no-install-recommends \
+  bash \
+  unzip \
+  vim \
+  build-essential \
+  make \
+  cmake \
+  wget \
+  curl \
+  lv \
+  less \
+  git \
+  imagemagick \
+  ffmpeg \
+  libfreetype6-dev \
+  libpng-dev \
+  libsm6 \
+  libxext6 \
+  libx11-xcb-dev \
+  libglu1-mesa-dev \
+  libxrender-dev \
+  libzmq3-dev \
+  python3.6-dev \
+  python3-pip \
+  python3.6-tk \
+  pkg-config \
+  libssl-dev \
+  zlib1g-dev \
+  libbz2-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  llvm \
+  libncurses5-dev \
+  libncursesw5-dev \
+  xz-utils \
+  tk-dev \
+  libffi-dev \
+  liblzma-dev \
+  protobuf-compiler
+
+# pip3
+RUN python3.6 -m pip install --upgrade \
+  pip \
+  setuptools
+
+# python lib
+RUN python3.6 -m pip install  --use-feature=2020-resolver \
+  opencv-python \
+  matplotlib \
+  scipy \
+  numba \
+  imgaug \
+  numpy \
+  torch==1.4.0 \
+  torchvision==0.5.0 \
+  Pillow==6.2.1 \
+  tqdm \
+  motmetrics==1.1.3 \
+  Cython \
+  progress \
+  easydict \
+  pyquaternion \
+  nuscenes-devkit \
+  pyyaml \
+  # for motmetrics
+  pandas==0.25.3 \
+  scikit-learn==0.22.2
+
+RUN python3.6 -m pip install --use-feature=2020-resolver -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
+
+COPY . /CenterTrack
+
+# check cuda
+RUN python -c 'import torch; assert torch.cuda.is_available(), "Cuda is not available."'
+WORKDIR /CenterTrack/src/lib/model/networks
+RUN git clone --recursive https://github.com/CharlesShang/DCNv2
+RUN cd DCNv2 && bash ./make.sh
+
+WORKDIR /CenterTrack
+
+# clean up
+RUN sudo apt-get clean and; \
+  sudo rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
Everyone seems to be having trouble with issue about GPU compilation of DCNv2, so I added a Dockerfile that works correctly.

We have confirmed the operation in the following environment.

```bash
⋊> ~ cat /etc/os-release | grep PRETTY_NAME
PRETTY_NAME="Ubuntu 18.04.2 LTS"
⋊> ~ docker --version
Docker version 19.03.5, build 633a0ea838
⋊> ~ docker info | grep -i runtime
WARNING: No swap limit support
 Runtimes: nvidia runc
 Default Runtime: nvidia
⋊> ~ 
```

If you want to use cuda when building docker container, you need to set the following `daemon.json`.

```json
⋊> ~ cat /etc/docker/daemon.json
{
    "default-runtime": "nvidia",
    "runtimes": {
    "nvidia": {
      "path": "/usr/bin/nvidia-container-runtime",
      "runtimeArgs": []
    }
  }
}
```

After preparing the above environment, execute Docker build with the following command.

```bash
docker-compose up -d dev
```

You cannot build with cuda unless you add the following to `docker-compose.yaml`.

```yml
    runtime: nvidia
    environment:
      - NVIDIA_VISIBLE_DEVICES=all
      - NVIDIA_DRIVER_CAPABILITIES=all
```

For Docker 19.03 and later versions, use the `--gpus all` option. Execute the docker run command as follows.

```bash
docker run --gpus all --ipc=host --rm -it \
         -v /home/keiichi.kuroyanagi/datasets/:/CenterTrack/data/ \
         -v /home/keiichi.kuroyanagi/pretrained_models/:/CenterTrack/models/ \
         centertrack_dev
```
