### PR TITLE
[Bug Fix] Make result converting script to work with default MOT17 structure

### DIFF
--- a/src/tools/convert_mot_det_to_results.py
+++ b/src/tools/convert_mot_det_to_results.py
@@ -4,15 +4,16 @@ import os
 from collections import defaultdict
 split = 'val_half'
 
-DET_PATH = '../../data/mot17/'
+DET_PATH = '../../data/mot17/train'
 ANN_PATH = '../../data/mot17/annotations/{}.json'.format(split)
 OUT_DIR = '../../data/mot17/results/'
 OUT_PATH = OUT_DIR + '{}_det.json'.format(split)
+IS_THIRD_PARTY = False
 
 if __name__ == '__main__':
   if not os.path.exists(OUT_DIR):
     os.mkdir(OUT_DIR)
-  seqs = [s for s in os.listdir(DET_PATH) if '_det' in s]
+  seqs = [s for s in os.listdir(DET_PATH)]
   data = json.load(open(ANN_PATH, 'r'))
   images = data['images']
   image_to_anns = defaultdict(list)


### PR DESCRIPTION
The current script will generate a JSON file with no public detection bbox since no folder name passes the '_det' check. I don't fully understand the use of that check. The changes I made here make it work with the default MOT17 structure. Please consider merge this or provide a better fix so that public evaluation can actually run. Thank you.