### PR TITLE
Enforce Cython version for COCOAPI installation

### DIFF
--- a/readme/INSTALL.md
+++ b/readme/INSTALL.md
@@ -26,7 +26,7 @@ After installing Anaconda:
 2. Install [COCOAPI](https://github.com/cocodataset/cocoapi):
 
     ~~~
-    pip install cython; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
+    pip install cython==0.29.33; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
     ~~~
 
 3. Clone this repo:


### PR DESCRIPTION
This pull request addresses compatibility issues between newer Cython versions and pycocotools. Specifying an older, compatible Cython version ensures successful COCOAPI installation.

Refer to the COCOAPI issue [#141](https://github.com/cocodataset/cocoapi/issues/141) for more details.